### PR TITLE
Support Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
         "email": "christoffer.fredriksen@sempro.no"
     }],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.3",
         "ext-json": "*",
-        "socialiteproviders/manager": "^2.0"
+        "socialiteproviders/manager": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Bumped socialiteproviders/manager to 4.0 and minimum PHP version to 7.3 as I couldn't initialize this provider in my Laravel 8 project.

Med julehilsen fra Empatix AS :)