### PR TITLE
Adds compatibility changes to Guzzle 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+.idea
+composer.lock

--- a/Provider.php
+++ b/Provider.php
@@ -3,8 +3,8 @@
 namespace SocialiteProviders\Vipps;
 
 use GuzzleHttp\ClientInterface;
-use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 
 class Provider extends AbstractProvider
 {
@@ -86,7 +86,7 @@ class Provider extends AbstractProvider
      */
     public function getAccessTokenResponse($code)
     {
-        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+        $postKey = (version_compare(ClientInterface::MAJOR_VERSION, '6') === 1) ? 'form_params' : 'body';
 
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => [

--- a/Provider.php
+++ b/Provider.php
@@ -18,8 +18,8 @@ class Provider extends AbstractProvider
      */
     protected $scopes = [
         'openid',
-        'api_version_2',
         'phoneNumber',
+        'api_version_2',
     ];
 
     /**
@@ -28,6 +28,24 @@ class Provider extends AbstractProvider
     protected $scopeSeparator = ' ';
 
     private $localUrlCache = null;
+
+    public static function additionalConfigKeys()
+    {
+        return ['base_url', 'additional_scopes'];
+    }
+
+    public function getScopes()
+    {
+        return array_merge(
+            parent::getScopes(),
+            $this->getConfig('additional_scopes', [])
+        );
+    }
+
+    protected function baseUrl()
+    {
+        return $this->getConfig('base_url', 'api.vipps.no');
+    }
 
     /**
      * {@inheritdoc}
@@ -110,8 +128,10 @@ class Provider extends AbstractProvider
 
     private function buildLocalUrlCache()
     {
+        $baseUrl = $this->baseUrl();
+
         $response = $this->getHttpClient()->get(
-            'https://api.vipps.no/access-management-1.0/access/.well-known/openid-configuration'
+            "https://{$baseUrl}/access-management-1.0/access/.well-known/openid-configuration"
         );
 
         $this->localUrlCache = json_decode($response->getBody(), true);

--- a/Provider.php
+++ b/Provider.php
@@ -86,7 +86,7 @@ class Provider extends AbstractProvider
      */
     public function getAccessTokenResponse($code)
     {
-        $postKey = (version_compare(ClientInterface::MAJOR_VERSION, '6') === 1) ? 'form_params' : 'body';
+        $postKey = (version_compare($this->getGuzzleVersion(), '6') === 1) ? 'form_params' : 'body';
 
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => [
@@ -115,5 +115,14 @@ class Provider extends AbstractProvider
         );
 
         $this->localUrlCache = json_decode($response->getBody(), true);
+    }
+
+    private function getGuzzleVersion()
+    {
+        if (defined(ClientInterface::class . '::VERSION')) {
+            return ClientInterface::VERSION;
+        }
+
+        return ClientInterface::MAJOR_VERSION;
     }
 }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ You will need to add an entry to the services configuration file so that after c
     'client_id' => env('VIPPS_CLIENT_ID'),
     'client_secret' => env('VIPPS_CLIENT_SECRET'),
     'redirect' => env('VIPPS_REDIRECT_URI'),
+    'base_url' => env('VIPPS_BASE_URL'), // not required, defaults to api.vipps.no
+    'additional_scopes' => [], // not required, use this to request additional data, like name and email (see https://api.vipps.no/access-management-1.0/access/.well-known/openid-configuration for additional supported scopes)
 ],
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "email": "christoffer.fredriksen@sempro.no"
     }],
     "require": {
-        "php": "^7.3",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },


### PR DESCRIPTION
Noticed my previous PR didn't actually work with Laravel 8, because Guzzle has been bumped to v7. Guzzle-maintainers decided to change the name of the `VERSION` constant to `MAJOR_VERSION`.

Also organized import-statements because I'm nuts.

Not sure if this is the best way to go about it, but I'm happy to make changes if you got any input.